### PR TITLE
Create UI

### DIFF
--- a/DnDCharacterGenerator.xcodeproj/project.pbxproj
+++ b/DnDCharacterGenerator.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		06650D082288557300226AB6 /* ApolloService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06650D072288557300226AB6 /* ApolloService.swift */; };
 		06650D0C22885A0F00226AB6 /* CharacterClassQuery.graphql in Resources */ = {isa = PBXBuildFile; fileRef = 06650D0B22885A0F00226AB6 /* CharacterClassQuery.graphql */; };
 		06650D0E2288C38900226AB6 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 06650D0D2288C38900226AB6 /* Images.xcassets */; };
+		06650D102288E14600226AB6 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 06650D0F2288E14600226AB6 /* Colors.xcassets */; };
 		06A63563228755D800CA6867 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06A63562228755D800CA6867 /* AppDelegate.swift */; };
 		06A63565228755D800CA6867 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06A63564228755D800CA6867 /* ViewController.swift */; };
 		06A63568228755D800CA6867 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 06A63566228755D800CA6867 /* Main.storyboard */; };
@@ -36,6 +37,7 @@
 		06650D072288557300226AB6 /* ApolloService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApolloService.swift; sourceTree = "<group>"; };
 		06650D0B22885A0F00226AB6 /* CharacterClassQuery.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = CharacterClassQuery.graphql; sourceTree = "<group>"; };
 		06650D0D2288C38900226AB6 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		06650D0F2288E14600226AB6 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		06A6355F228755D800CA6867 /* DnDCharacterGenerator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DnDCharacterGenerator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		06A63562228755D800CA6867 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		06A63564228755D800CA6867 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -126,6 +128,7 @@
 				06A6356B228755DB00CA6867 /* LaunchScreen.storyboard */,
 				06A6356E228755DB00CA6867 /* Info.plist */,
 				06650D0D2288C38900226AB6 /* Images.xcassets */,
+				06650D0F2288E14600226AB6 /* Colors.xcassets */,
 			);
 			path = DnDCharacterGenerator;
 			sourceTree = "<group>";
@@ -250,6 +253,7 @@
 				06650D0E2288C38900226AB6 /* Images.xcassets in Resources */,
 				06A6356A228755DB00CA6867 /* Assets.xcassets in Resources */,
 				06A63568228755D800CA6867 /* Main.storyboard in Resources */,
+				06650D102288E14600226AB6 /* Colors.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DnDCharacterGenerator.xcodeproj/project.pbxproj
+++ b/DnDCharacterGenerator.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		06650D082288557300226AB6 /* ApolloService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06650D072288557300226AB6 /* ApolloService.swift */; };
 		06650D0C22885A0F00226AB6 /* CharacterClassQuery.graphql in Resources */ = {isa = PBXBuildFile; fileRef = 06650D0B22885A0F00226AB6 /* CharacterClassQuery.graphql */; };
+		06650D0E2288C38900226AB6 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 06650D0D2288C38900226AB6 /* Images.xcassets */; };
 		06A63563228755D800CA6867 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06A63562228755D800CA6867 /* AppDelegate.swift */; };
 		06A63565228755D800CA6867 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06A63564228755D800CA6867 /* ViewController.swift */; };
 		06A63568228755D800CA6867 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 06A63566228755D800CA6867 /* Main.storyboard */; };
@@ -34,6 +35,7 @@
 /* Begin PBXFileReference section */
 		06650D072288557300226AB6 /* ApolloService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApolloService.swift; sourceTree = "<group>"; };
 		06650D0B22885A0F00226AB6 /* CharacterClassQuery.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = CharacterClassQuery.graphql; sourceTree = "<group>"; };
+		06650D0D2288C38900226AB6 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		06A6355F228755D800CA6867 /* DnDCharacterGenerator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DnDCharacterGenerator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		06A63562228755D800CA6867 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		06A63564228755D800CA6867 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -123,6 +125,7 @@
 				06A63569228755DB00CA6867 /* Assets.xcassets */,
 				06A6356B228755DB00CA6867 /* LaunchScreen.storyboard */,
 				06A6356E228755DB00CA6867 /* Info.plist */,
+				06650D0D2288C38900226AB6 /* Images.xcassets */,
 			);
 			path = DnDCharacterGenerator;
 			sourceTree = "<group>";
@@ -244,6 +247,7 @@
 				06A635842287633B00CA6867 /* schema.json in Resources */,
 				06650D0C22885A0F00226AB6 /* CharacterClassQuery.graphql in Resources */,
 				06A6356D228755DB00CA6867 /* LaunchScreen.storyboard in Resources */,
+				06650D0E2288C38900226AB6 /* Images.xcassets in Resources */,
 				06A6356A228755DB00CA6867 /* Assets.xcassets in Resources */,
 				06A63568228755D800CA6867 /* Main.storyboard in Resources */,
 			);

--- a/DnDCharacterGenerator/Base.lproj/Main.storyboard
+++ b/DnDCharacterGenerator/Base.lproj/Main.storyboard
@@ -24,7 +24,7 @@
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="600" translatesAutoresizingMaskIntoConstraints="NO" id="TPN-ey-CrU">
                                 <rect key="frame" x="20" y="64" width="374" height="778"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="lmC-wL-0ME">
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="lmC-wL-0ME" userLabel="Class Label Stack View">
                                         <rect key="frame" x="0.0" y="0.0" width="374" height="70"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Class:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7EE-DN-vrw">

--- a/DnDCharacterGenerator/Base.lproj/Main.storyboard
+++ b/DnDCharacterGenerator/Base.lproj/Main.storyboard
@@ -25,16 +25,19 @@
                                 <rect key="frame" x="20" y="64" width="374" height="778"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="lmC-wL-0ME" userLabel="Class Label Stack View">
-                                        <rect key="frame" x="0.0" y="0.0" width="374" height="70"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="374" height="100"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Class:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7EE-DN-vrw">
-                                                <rect key="frame" x="0.0" y="0.0" width="374" height="32.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Class:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7EE-DN-vrw">
+                                                <rect key="frame" x="0.0" y="0.0" width="374" height="33"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="33" id="9KA-PD-iCO"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="27"/>
                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Odp-hW-pES">
-                                                <rect key="frame" x="0.0" y="37.5" width="374" height="32.5"/>
+                                                <rect key="frame" x="0.0" y="38" width="374" height="62"/>
                                                 <color key="backgroundColor" red="0.060530272228689647" green="0.1031723509809095" blue="0.1455279926246632" alpha="0.60076474471830987" colorSpace="custom" customColorSpace="displayP3"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="27"/>
                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -43,16 +46,19 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="3qb-qb-lUk" userLabel="Race Label Stack View">
-                                        <rect key="frame" x="0.0" y="170" width="374" height="70"/>
+                                        <rect key="frame" x="0.0" y="200" width="374" height="100"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Race:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="M1S-pU-UEN">
-                                                <rect key="frame" x="0.0" y="0.0" width="374" height="32.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="374" height="33"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="33" id="UGa-gK-3Yh"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="27"/>
                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kfm-o2-iQO">
-                                                <rect key="frame" x="0.0" y="37.5" width="374" height="32.5"/>
+                                                <rect key="frame" x="0.0" y="38" width="374" height="62"/>
                                                 <color key="backgroundColor" red="0.060530272230000001" green="0.103172351" blue="0.14552799259999999" alpha="0.60076474469999996" colorSpace="custom" customColorSpace="displayP3"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="27"/>
                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -62,16 +68,19 @@
                                         <viewLayoutGuide key="safeArea" id="xbf-ZE-oZ9"/>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="W6O-gs-Ea0" userLabel="Alignment Label Stack View">
-                                        <rect key="frame" x="0.0" y="340" width="374" height="70"/>
+                                        <rect key="frame" x="0.0" y="400" width="374" height="103"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Alignment:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tBI-DK-gcS">
-                                                <rect key="frame" x="0.0" y="0.0" width="374" height="32.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="374" height="33"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="33" id="arH-7I-fIH"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="27"/>
                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ci3-Xc-ZZH">
-                                                <rect key="frame" x="0.0" y="37.5" width="374" height="32.5"/>
+                                                <rect key="frame" x="0.0" y="38" width="374" height="65"/>
                                                 <color key="backgroundColor" red="0.060530272230000001" green="0.103172351" blue="0.14552799259999999" alpha="0.60076474469999996" colorSpace="custom" customColorSpace="displayP3"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="27"/>
                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -81,8 +90,11 @@
                                         <viewLayoutGuide key="safeArea" id="ogb-Bg-iUh"/>
                                     </stackView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Yap-Hq-xwe">
-                                        <rect key="frame" x="0.0" y="510" width="374" height="268"/>
+                                        <rect key="frame" x="0.0" y="603" width="374" height="175"/>
                                         <color key="backgroundColor" red="0.21383166688198635" green="0.0014901012205789409" blue="0.42100469559585496" alpha="0.69999999999999996" colorSpace="custom" customColorSpace="displayP3"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="175" id="XgW-lT-RbP"/>
+                                        </constraints>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="27"/>
                                         <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <state key="normal" title="Generate Character"/>
@@ -91,6 +103,10 @@
                                         </connections>
                                     </button>
                                 </subviews>
+                                <constraints>
+                                    <constraint firstItem="3qb-qb-lUk" firstAttribute="top" secondItem="TPN-ey-CrU" secondAttribute="top" constant="200" id="hvc-XQ-gPK"/>
+                                    <constraint firstItem="W6O-gs-Ea0" firstAttribute="top" secondItem="TPN-ey-CrU" secondAttribute="top" constant="400" id="uCm-gH-28H"/>
+                                </constraints>
                             </stackView>
                         </subviews>
                         <color key="backgroundColor" red="0.041549888600000001" green="0.070597892110000005" blue="0.099138743919999994" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>

--- a/DnDCharacterGenerator/Base.lproj/Main.storyboard
+++ b/DnDCharacterGenerator/Base.lproj/Main.storyboard
@@ -45,6 +45,9 @@
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="27"/>
                                         <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <state key="normal" title="Generate Character"/>
+                                        <connections>
+                                            <action selector="generateButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Ys5-Gm-Xga"/>
+                                        </connections>
                                     </button>
                                 </subviews>
                             </stackView>

--- a/DnDCharacterGenerator/Base.lproj/Main.storyboard
+++ b/DnDCharacterGenerator/Base.lproj/Main.storyboard
@@ -6,6 +6,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -19,7 +20,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="sunlit-path-ian-tormo" translatesAutoresizingMaskIntoConstraints="NO" id="He6-3j-ccJ">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414.00000000000091" height="896"/>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="100" translatesAutoresizingMaskIntoConstraints="NO" id="TPN-ey-CrU">
                                 <rect key="frame" x="20" y="64" width="374" height="503"/>
@@ -38,7 +39,7 @@
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Odp-hW-pES">
                                                 <rect key="frame" x="0.0" y="38" width="374" height="62"/>
-                                                <color key="backgroundColor" red="0.060530272228689647" green="0.1031723509809095" blue="0.1455279926246632" alpha="0.60076474471830987" colorSpace="custom" customColorSpace="displayP3"/>
+                                                <color key="backgroundColor" name="LabelColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="27"/>
                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -59,7 +60,7 @@
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kfm-o2-iQO">
                                                 <rect key="frame" x="0.0" y="38" width="374" height="62"/>
-                                                <color key="backgroundColor" red="0.060530272230000001" green="0.103172351" blue="0.14552799259999999" alpha="0.60076474469999996" colorSpace="custom" customColorSpace="displayP3"/>
+                                                <color key="backgroundColor" name="LabelColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="27"/>
                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -81,7 +82,7 @@
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ci3-Xc-ZZH">
                                                 <rect key="frame" x="0.0" y="38" width="374" height="65"/>
-                                                <color key="backgroundColor" red="0.060530272230000001" green="0.103172351" blue="0.14552799259999999" alpha="0.60076474469999996" colorSpace="custom" customColorSpace="displayP3"/>
+                                                <color key="backgroundColor" name="LabelColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="27"/>
                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -97,7 +98,7 @@
                             </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Yap-Hq-xwe">
                                 <rect key="frame" x="20" y="742" width="374" height="100"/>
-                                <color key="backgroundColor" red="0.21383166688198635" green="0.0014901012205789409" blue="0.42100469559585496" alpha="0.69999999999999996" colorSpace="custom" customColorSpace="displayP3"/>
+                                <color key="backgroundColor" name="ButtonColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="100" id="XgW-lT-RbP"/>
                                 </constraints>
@@ -139,5 +140,11 @@
     </scenes>
     <resources>
         <image name="sunlit-path-ian-tormo" width="4863" height="3233"/>
+        <namedColor name="ButtonColor">
+            <color red="0.2370000034570694" green="0.0" blue="0.43900001049041748" alpha="0.69999998807907104" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="LabelColor">
+            <color red="0.046999998390674591" green="0.10499999672174454" blue="0.15000000596046448" alpha="0.60100001096725464" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
     </resources>
 </document>

--- a/DnDCharacterGenerator/Base.lproj/Main.storyboard
+++ b/DnDCharacterGenerator/Base.lproj/Main.storyboard
@@ -22,7 +22,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="414.00000000000091" height="896"/>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="100" translatesAutoresizingMaskIntoConstraints="NO" id="TPN-ey-CrU">
-                                <rect key="frame" x="20" y="64" width="374" height="778"/>
+                                <rect key="frame" x="20" y="64" width="374" height="503"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="lmC-wL-0ME" userLabel="Class Label Stack View">
                                         <rect key="frame" x="0.0" y="0.0" width="374" height="100"/>
@@ -89,34 +89,37 @@
                                         </subviews>
                                         <viewLayoutGuide key="safeArea" id="ogb-Bg-iUh"/>
                                     </stackView>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Yap-Hq-xwe">
-                                        <rect key="frame" x="0.0" y="603" width="374" height="175"/>
-                                        <color key="backgroundColor" red="0.21383166688198635" green="0.0014901012205789409" blue="0.42100469559585496" alpha="0.69999999999999996" colorSpace="custom" customColorSpace="displayP3"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="175" id="XgW-lT-RbP"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="27"/>
-                                        <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        <state key="normal" title="Generate Character"/>
-                                        <connections>
-                                            <action selector="generateButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Ys5-Gm-Xga"/>
-                                        </connections>
-                                    </button>
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="3qb-qb-lUk" firstAttribute="top" secondItem="TPN-ey-CrU" secondAttribute="top" constant="200" id="hvc-XQ-gPK"/>
                                     <constraint firstItem="W6O-gs-Ea0" firstAttribute="top" secondItem="TPN-ey-CrU" secondAttribute="top" constant="400" id="uCm-gH-28H"/>
                                 </constraints>
                             </stackView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Yap-Hq-xwe">
+                                <rect key="frame" x="20" y="742" width="374" height="100"/>
+                                <color key="backgroundColor" red="0.21383166688198635" green="0.0014901012205789409" blue="0.42100469559585496" alpha="0.69999999999999996" colorSpace="custom" customColorSpace="displayP3"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="100" id="XgW-lT-RbP"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="27"/>
+                                <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <state key="normal" title="Generate Character"/>
+                                <connections>
+                                    <action selector="generateButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Ys5-Gm-Xga"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="0.041549888600000001" green="0.070597892110000005" blue="0.099138743919999994" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="He6-3j-ccJ" secondAttribute="trailing" id="1qf-FE-PVc"/>
                             <constraint firstItem="He6-3j-ccJ" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="242-hz-IE7"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="Yap-Hq-xwe" secondAttribute="trailing" constant="20" id="4Qj-ne-wcw"/>
                             <constraint firstItem="TPN-ey-CrU" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="56h-ra-5DE"/>
                             <constraint firstItem="He6-3j-ccJ" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="ARk-xZ-71W"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="TPN-ey-CrU" secondAttribute="bottom" constant="20" id="GlQ-S9-5TI"/>
+                            <constraint firstItem="Yap-Hq-xwe" firstAttribute="top" secondItem="TPN-ey-CrU" secondAttribute="bottom" constant="175" id="GlQ-S9-5TI"/>
                             <constraint firstAttribute="bottom" secondItem="He6-3j-ccJ" secondAttribute="bottom" id="KYB-q1-vZV"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="Yap-Hq-xwe" secondAttribute="bottom" constant="20" id="LBb-MC-z96"/>
+                            <constraint firstItem="Yap-Hq-xwe" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="YIh-LY-ovU"/>
                             <constraint firstItem="TPN-ey-CrU" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="20" id="eOo-yr-OfJ"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="TPN-ey-CrU" secondAttribute="trailing" constant="20" id="sxg-6m-L0D"/>
                         </constraints>

--- a/DnDCharacterGenerator/Base.lproj/Main.storyboard
+++ b/DnDCharacterGenerator/Base.lproj/Main.storyboard
@@ -21,7 +21,7 @@
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="sunlit-path-ian-tormo" translatesAutoresizingMaskIntoConstraints="NO" id="He6-3j-ccJ">
                                 <rect key="frame" x="0.0" y="0.0" width="414.00000000000091" height="896"/>
                             </imageView>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="600" translatesAutoresizingMaskIntoConstraints="NO" id="TPN-ey-CrU">
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="100" translatesAutoresizingMaskIntoConstraints="NO" id="TPN-ey-CrU">
                                 <rect key="frame" x="20" y="64" width="374" height="778"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="lmC-wL-0ME" userLabel="Class Label Stack View">
@@ -42,8 +42,46 @@
                                             </label>
                                         </subviews>
                                     </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="3qb-qb-lUk" userLabel="Race Label Stack View">
+                                        <rect key="frame" x="0.0" y="170" width="374" height="70"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Race:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="M1S-pU-UEN">
+                                                <rect key="frame" x="0.0" y="0.0" width="374" height="32.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="27"/>
+                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kfm-o2-iQO">
+                                                <rect key="frame" x="0.0" y="37.5" width="374" height="32.5"/>
+                                                <color key="backgroundColor" red="0.060530272230000001" green="0.103172351" blue="0.14552799259999999" alpha="0.60076474469999996" colorSpace="custom" customColorSpace="displayP3"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="27"/>
+                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <viewLayoutGuide key="safeArea" id="xbf-ZE-oZ9"/>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="W6O-gs-Ea0" userLabel="Alignment Label Stack View">
+                                        <rect key="frame" x="0.0" y="340" width="374" height="70"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Alignment:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tBI-DK-gcS">
+                                                <rect key="frame" x="0.0" y="0.0" width="374" height="32.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="27"/>
+                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ci3-Xc-ZZH">
+                                                <rect key="frame" x="0.0" y="37.5" width="374" height="32.5"/>
+                                                <color key="backgroundColor" red="0.060530272230000001" green="0.103172351" blue="0.14552799259999999" alpha="0.60076474469999996" colorSpace="custom" customColorSpace="displayP3"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="27"/>
+                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <viewLayoutGuide key="safeArea" id="ogb-Bg-iUh"/>
+                                    </stackView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Yap-Hq-xwe">
-                                        <rect key="frame" x="0.0" y="670" width="374" height="108"/>
+                                        <rect key="frame" x="0.0" y="510" width="374" height="268"/>
                                         <color key="backgroundColor" red="0.21383166688198635" green="0.0014901012205789409" blue="0.42100469559585496" alpha="0.69999999999999996" colorSpace="custom" customColorSpace="displayP3"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="27"/>
                                         <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/DnDCharacterGenerator/Base.lproj/Main.storyboard
+++ b/DnDCharacterGenerator/Base.lproj/Main.storyboard
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -9,13 +13,54 @@
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="DnDCharacterGenerator" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="600" translatesAutoresizingMaskIntoConstraints="NO" id="TPN-ey-CrU">
+                                <rect key="frame" x="20" y="64" width="374" height="778"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="lmC-wL-0ME">
+                                        <rect key="frame" x="0.0" y="0.0" width="374" height="70"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Class:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7EE-DN-vrw">
+                                                <rect key="frame" x="0.0" y="0.0" width="374" height="32.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="27"/>
+                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Odp-hW-pES">
+                                                <rect key="frame" x="0.0" y="37.5" width="374" height="32.5"/>
+                                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.88366527289999997" colorSpace="custom" customColorSpace="displayP3"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="27"/>
+                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Yap-Hq-xwe">
+                                        <rect key="frame" x="0.0" y="670" width="374" height="108"/>
+                                        <color key="backgroundColor" red="1" green="0.0" blue="0.5714479496" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="27"/>
+                                        <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <state key="normal" title="Generate Character"/>
+                                    </button>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <color key="backgroundColor" red="0.041549888600000001" green="0.070597892110000005" blue="0.099138743919999994" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                        <constraints>
+                            <constraint firstItem="TPN-ey-CrU" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="56h-ra-5DE"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="TPN-ey-CrU" secondAttribute="bottom" constant="20" id="GlQ-S9-5TI"/>
+                            <constraint firstItem="TPN-ey-CrU" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="20" id="eOo-yr-OfJ"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="TPN-ey-CrU" secondAttribute="trailing" constant="20" id="sxg-6m-L0D"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
+                    <connections>
+                        <outlet property="classLabel" destination="Odp-hW-pES" id="CF6-lG-Bxg"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/DnDCharacterGenerator/Base.lproj/Main.storyboard
+++ b/DnDCharacterGenerator/Base.lproj/Main.storyboard
@@ -18,6 +18,9 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="sunlit-path-ian-tormo" translatesAutoresizingMaskIntoConstraints="NO" id="He6-3j-ccJ">
+                                <rect key="frame" x="0.0" y="0.0" width="414.00000000000091" height="896"/>
+                            </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="600" translatesAutoresizingMaskIntoConstraints="NO" id="TPN-ey-CrU">
                                 <rect key="frame" x="20" y="64" width="374" height="778"/>
                                 <subviews>
@@ -30,9 +33,9 @@
                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Odp-hW-pES">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Odp-hW-pES">
                                                 <rect key="frame" x="0.0" y="37.5" width="374" height="32.5"/>
-                                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.88366527289999997" colorSpace="custom" customColorSpace="displayP3"/>
+                                                <color key="backgroundColor" red="0.060530272228689647" green="0.1031723509809095" blue="0.1455279926246632" alpha="0.60076474471830987" colorSpace="custom" customColorSpace="displayP3"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="27"/>
                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -41,7 +44,7 @@
                                     </stackView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Yap-Hq-xwe">
                                         <rect key="frame" x="0.0" y="670" width="374" height="108"/>
-                                        <color key="backgroundColor" red="1" green="0.0" blue="0.5714479496" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                        <color key="backgroundColor" red="0.21383166688198635" green="0.0014901012205789409" blue="0.42100469559585496" alpha="0.69999999999999996" colorSpace="custom" customColorSpace="displayP3"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="27"/>
                                         <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <state key="normal" title="Generate Character"/>
@@ -54,19 +57,28 @@
                         </subviews>
                         <color key="backgroundColor" red="0.041549888600000001" green="0.070597892110000005" blue="0.099138743919999994" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                         <constraints>
+                            <constraint firstAttribute="trailing" secondItem="He6-3j-ccJ" secondAttribute="trailing" id="1qf-FE-PVc"/>
+                            <constraint firstItem="He6-3j-ccJ" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="242-hz-IE7"/>
                             <constraint firstItem="TPN-ey-CrU" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="56h-ra-5DE"/>
+                            <constraint firstItem="He6-3j-ccJ" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="ARk-xZ-71W"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="TPN-ey-CrU" secondAttribute="bottom" constant="20" id="GlQ-S9-5TI"/>
+                            <constraint firstAttribute="bottom" secondItem="He6-3j-ccJ" secondAttribute="bottom" id="KYB-q1-vZV"/>
                             <constraint firstItem="TPN-ey-CrU" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="20" id="eOo-yr-OfJ"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="TPN-ey-CrU" secondAttribute="trailing" constant="20" id="sxg-6m-L0D"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                     <connections>
+                        <outlet property="backgroundImageView" destination="He6-3j-ccJ" id="ffz-w8-ksT"/>
                         <outlet property="classLabel" destination="Odp-hW-pES" id="CF6-lG-Bxg"/>
+                        <outlet property="generateButton" destination="Yap-Hq-xwe" id="3ik-3n-wED"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
         </scene>
     </scenes>
+    <resources>
+        <image name="sunlit-path-ian-tormo" width="4863" height="3233"/>
+    </resources>
 </document>

--- a/DnDCharacterGenerator/Base.lproj/Main.storyboard
+++ b/DnDCharacterGenerator/Base.lproj/Main.storyboard
@@ -19,7 +19,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="sunlit-path-ian-tormo" translatesAutoresizingMaskIntoConstraints="NO" id="He6-3j-ccJ">
-                                <rect key="frame" x="0.0" y="0.0" width="414.00000000000091" height="896"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="100" translatesAutoresizingMaskIntoConstraints="NO" id="TPN-ey-CrU">
                                 <rect key="frame" x="20" y="64" width="374" height="503"/>
@@ -126,9 +126,11 @@
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                     <connections>
+                        <outlet property="alignmentLabel" destination="Ci3-Xc-ZZH" id="lTE-Ka-1h1"/>
                         <outlet property="backgroundImageView" destination="He6-3j-ccJ" id="ffz-w8-ksT"/>
                         <outlet property="classLabel" destination="Odp-hW-pES" id="CF6-lG-Bxg"/>
                         <outlet property="generateButton" destination="Yap-Hq-xwe" id="3ik-3n-wED"/>
+                        <outlet property="raceLabel" destination="kfm-o2-iQO" id="U6g-ga-Ja1"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/DnDCharacterGenerator/Colors.xcassets/ButtonColor.colorset/Contents.json
+++ b/DnDCharacterGenerator/Colors.xcassets/ButtonColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.237",
+          "alpha" : "0.700",
+          "blue" : "0.439",
+          "green" : "0.000"
+        }
+      }
+    }
+  ]
+}

--- a/DnDCharacterGenerator/Colors.xcassets/Contents.json
+++ b/DnDCharacterGenerator/Colors.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/DnDCharacterGenerator/Colors.xcassets/LabelColor.colorset/Contents.json
+++ b/DnDCharacterGenerator/Colors.xcassets/LabelColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.047",
+          "alpha" : "0.601",
+          "blue" : "0.150",
+          "green" : "0.105"
+        }
+      }
+    }
+  ]
+}

--- a/DnDCharacterGenerator/Colors.xcassets/LightColor.colorset/Contents.json
+++ b/DnDCharacterGenerator/Colors.xcassets/LightColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "255",
+          "alpha" : "0.500",
+          "blue" : "213",
+          "green" : "245"
+        }
+      }
+    }
+  ]
+}

--- a/DnDCharacterGenerator/Images.xcassets/Contents.json
+++ b/DnDCharacterGenerator/Images.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/DnDCharacterGenerator/Images.xcassets/sunlit-path-ian-tormo.imageset/Contents.json
+++ b/DnDCharacterGenerator/Images.xcassets/sunlit-path-ian-tormo.imageset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "filename" : "sunlit-path-ian-tormo.png",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/DnDCharacterGenerator/ViewController.swift
+++ b/DnDCharacterGenerator/ViewController.swift
@@ -24,21 +24,25 @@ class ViewController: UIViewController {
     @IBOutlet weak var classLabel: UILabel!
     
     let characterClassQuery = CharacterClassQuery()
+    var allCharacterClasses: [String] = []
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        classLabel.text = "\t"
         ApolloService.shared.client.fetch(query: characterClassQuery) { results, error in
             if error != nil {
                 print("⛔️ Error in fetching response: \(String(describing: error))")
             } else if let results = results?.data?.classResult?.allClasses?.compactMap({ $0 }) {
                 print(results)
-                let allCharacterClasses = results.map{ $0.name! }
-                print("⚔️ Classes: \(allCharacterClasses)")
-                self.classLabel.text = allCharacterClasses.reduce("", { $0 == "" ? $1 : $0 + "," + $1 })
+                self.allCharacterClasses = results.map{ $0.name! }
+                print("⚔️ Classes: \(self.allCharacterClasses)")
             }
         }
     }
 
+    @IBAction func generateButtonTapped(_ sender: UIButton) {
+        classLabel.text = allCharacterClasses.randomElement()
+    }
     
     
 

--- a/DnDCharacterGenerator/ViewController.swift
+++ b/DnDCharacterGenerator/ViewController.swift
@@ -22,7 +22,12 @@ import UIKit
 class ViewController: UIViewController {
     
     @IBOutlet weak var classLabel: UILabel!
+    @IBOutlet weak var generateButton: UIButton! {
+        didSet { generateButton.layer.cornerRadius = 20 }
+    }
+    @IBOutlet weak var backgroundImageView: UIImageView! 
     
+    var gradientLayer: CAGradientLayer!
     let characterClassQuery = CharacterClassQuery()
     var allCharacterClasses: [String] = []
     
@@ -38,6 +43,20 @@ class ViewController: UIViewController {
                 print("⚔️ Classes: \(self.allCharacterClasses)")
             }
         }
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        createGradientLayer()
+    }
+    
+    func createGradientLayer() {
+        gradientLayer = CAGradientLayer()
+        gradientLayer.frame = backgroundImageView.bounds
+        gradientLayer.colors = [UIColor.clear.cgColor, UIColor.lightText.cgColor]
+        
+        backgroundImageView.layer.addSublayer(gradientLayer)
+        generateButton.layer.zPosition = 1
     }
 
     @IBAction func generateButtonTapped(_ sender: UIButton) {

--- a/DnDCharacterGenerator/ViewController.swift
+++ b/DnDCharacterGenerator/ViewController.swift
@@ -21,6 +21,8 @@ import UIKit
 
 class ViewController: UIViewController {
     
+    @IBOutlet weak var classLabel: UILabel!
+    
     let characterClassQuery = CharacterClassQuery()
     
     override func viewDidLoad() {
@@ -32,6 +34,7 @@ class ViewController: UIViewController {
                 print(results)
                 let allCharacterClasses = results.map{ $0.name! }
                 print("⚔️ Classes: \(allCharacterClasses)")
+                self.classLabel.text = allCharacterClasses.reduce("", { $0 == "" ? $1 : $0 + "," + $1 })
             }
         }
     }

--- a/DnDCharacterGenerator/ViewController.swift
+++ b/DnDCharacterGenerator/ViewController.swift
@@ -22,6 +22,8 @@ import UIKit
 class ViewController: UIViewController {
     
     @IBOutlet weak var classLabel: UILabel!
+    @IBOutlet weak var raceLabel: UILabel!
+    @IBOutlet weak var alignmentLabel: UILabel!
     @IBOutlet weak var generateButton: UIButton! {
         didSet { generateButton.layer.cornerRadius = 20 }
     }
@@ -34,6 +36,8 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         classLabel.text = "\t"
+        raceLabel.text = "\t"
+        alignmentLabel.text = "\t"
         ApolloService.shared.client.fetch(query: characterClassQuery) { results, error in
             if error != nil {
                 print("⛔️ Error in fetching response: \(String(describing: error))")
@@ -61,6 +65,8 @@ class ViewController: UIViewController {
 
     @IBAction func generateButtonTapped(_ sender: UIButton) {
         classLabel.text = allCharacterClasses.randomElement()
+        raceLabel.text = "Half-Orc"
+        alignmentLabel.text = "Chaotic Neutral"
     }
     
     

--- a/DnDCharacterGenerator/ViewController.swift
+++ b/DnDCharacterGenerator/ViewController.swift
@@ -53,7 +53,7 @@ class ViewController: UIViewController {
     func createGradientLayer() {
         gradientLayer = CAGradientLayer()
         gradientLayer.frame = backgroundImageView.bounds
-        gradientLayer.colors = [UIColor.clear.cgColor, UIColor.lightText.cgColor]
+        gradientLayer.colors = [UIColor.clear.cgColor, UIColor(named: "LightColor")!.cgColor]
         
         backgroundImageView.layer.addSublayer(gradientLayer)
         generateButton.layer.zPosition = 1

--- a/DnDCharacterGenerator/ViewController.swift
+++ b/DnDCharacterGenerator/ViewController.swift
@@ -31,22 +31,13 @@ class ViewController: UIViewController {
     
     var gradientLayer: CAGradientLayer!
     let characterClassQuery = CharacterClassQuery()
+    var isDataFetched: Bool = false
     var allCharacterClasses: [String] = []
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        classLabel.text = "\t"
-        raceLabel.text = "\t"
-        alignmentLabel.text = "\t"
-        ApolloService.shared.client.fetch(query: characterClassQuery) { results, error in
-            if error != nil {
-                print("⛔️ Error in fetching response: \(String(describing: error))")
-            } else if let results = results?.data?.classResult?.allClasses?.compactMap({ $0 }) {
-                print(results)
-                self.allCharacterClasses = results.map{ $0.name! }
-                print("⚔️ Classes: \(self.allCharacterClasses)")
-            }
-        }
+        clearLabels()
+        tryDataFetch()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -54,7 +45,37 @@ class ViewController: UIViewController {
         createGradientLayer()
     }
     
-    func createGradientLayer() {
+    private func clearLabels() {
+        classLabel.text = "\t"
+        raceLabel.text = "\t"
+        alignmentLabel.text = "\t"
+    }
+    
+    private func populateLabels() {
+        if isDataFetched == false {
+            clearLabels()
+        } else {
+            classLabel.text = allCharacterClasses.randomElement()
+            raceLabel.text = "Half-Orc"
+            alignmentLabel.text = "Chaotic Neutral"
+        }
+    }
+    
+    private func tryDataFetch() {
+        ApolloService.shared.client.fetch(query: characterClassQuery) { results, error in
+            if error != nil {
+                self.isDataFetched = false
+                print("⛔️ Error in fetching response: \(String(describing: error))")
+            } else if let results = results?.data?.classResult?.allClasses?.compactMap({ $0 }) {
+                self.isDataFetched = true
+                print(results)
+                self.allCharacterClasses = results.map{ $0.name! }
+                print("⚔️ Classes: \(self.allCharacterClasses)")
+            }
+        }
+    }
+    
+    private func createGradientLayer() {
         gradientLayer = CAGradientLayer()
         gradientLayer.frame = backgroundImageView.bounds
         gradientLayer.colors = [UIColor.clear.cgColor, UIColor(named: "LightColor")!.cgColor]
@@ -64,9 +85,12 @@ class ViewController: UIViewController {
     }
 
     @IBAction func generateButtonTapped(_ sender: UIButton) {
-        classLabel.text = allCharacterClasses.randomElement()
-        raceLabel.text = "Half-Orc"
-        alignmentLabel.text = "Chaotic Neutral"
+        if isDataFetched == false {
+            tryDataFetch()
+            populateLabels()
+        } else {
+            populateLabels()
+        }
     }
     
     


### PR DESCRIPTION
## What does this PR do :question:
This PR contains changes related to creating and refining the UI. The functionality of the UI includes:
- Populating labels with the `Class` data returned from the request to the GraphQL server
- Returning a random `Class` in that label when the 'Generate Character' button is tapped
- Retrying the data fetch upon tapping the 'Generate Character' button if the data fetch failed the first time 


## How to test it :microscope:
⚙️**Precondition: The [dnd-graphql](https://github.com/BritneyS/dnd-graphql) server should be NOT be running on http://localhost:8000**
1. Checkout this branch
2. Run `pod install`
3. Run the app
4. Tap the 'Generate Character' button **(Important: The dnd-graphql server should not be running)**
5. Note that the labels on the screen remain blank, and the following error is printed to the console (expected!):
```
Error in fetching response: Optional(Error Domain=NSURLErrorDomain Code=-1004 "Could not connect to the server." UserInfo={NSUnderlyingError=0x600000249bf0 {Error Domain=kCFErrorDomainCFNetwork Code=-1004 "(null)" UserInfo={_kCFStreamErrorCodeKey=61, _kCFStreamErrorDomainKey=1}}, NSErrorFailingURLStringKey=http://localhost:8000/graphql, NSErrorFailingURLKey=http://localhost:8000/graphql, _kCFStreamErrorDomainKey=1, _kCFStreamErrorCodeKey=61, NSLocalizedDescription=Could not connect to the server.})
```
6. Run the dnd-graphql server (Navigate to the server's root directory in Terminal, and run `npm start`)
7. Tap the 'Generate Character` button twice
8. Note that the app labels are now populated
9. Tapping the 'Generate Character' button repeatedly should populate different class names in the `Class:` label


## Any background info you would like to include :white_check_mark:
Currently, only the `Class` data is returned from the D&D API. The `Race:` and `Alignment` labels are temporarily populated with `Half-Orc` and `Chaotic Neutral` respectively, until the schema and query is updated to include other results.


## Screenshots (if applicable) :camera:
![dndgenerator-pr-create-ui](https://user-images.githubusercontent.com/8409475/57650540-0a9cb900-7599-11e9-88a4-35e8c2f1f6ba.gif)

