### PR TITLE
Updated schema to include character races; added alignments not provided by D&D API

### DIFF
--- a/DnDCharacterGenerator.xcodeproj/project.pbxproj
+++ b/DnDCharacterGenerator.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		06650D0C22885A0F00226AB6 /* CharacterClassQuery.graphql in Resources */ = {isa = PBXBuildFile; fileRef = 06650D0B22885A0F00226AB6 /* CharacterClassQuery.graphql */; };
 		06650D0E2288C38900226AB6 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 06650D0D2288C38900226AB6 /* Images.xcassets */; };
 		06650D102288E14600226AB6 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 06650D0F2288E14600226AB6 /* Colors.xcassets */; };
+		06A03AAE228A0A4C0065A0E5 /* CharacterAttributesQuery.graphql in Resources */ = {isa = PBXBuildFile; fileRef = 06A03AAD228A0A4C0065A0E5 /* CharacterAttributesQuery.graphql */; };
 		06A63563228755D800CA6867 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06A63562228755D800CA6867 /* AppDelegate.swift */; };
 		06A63565228755D800CA6867 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06A63564228755D800CA6867 /* ViewController.swift */; };
 		06A63568228755D800CA6867 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 06A63566228755D800CA6867 /* Main.storyboard */; };
@@ -38,6 +39,7 @@
 		06650D0B22885A0F00226AB6 /* CharacterClassQuery.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = CharacterClassQuery.graphql; sourceTree = "<group>"; };
 		06650D0D2288C38900226AB6 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		06650D0F2288E14600226AB6 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
+		06A03AAD228A0A4C0065A0E5 /* CharacterAttributesQuery.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = CharacterAttributesQuery.graphql; sourceTree = "<group>"; };
 		06A6355F228755D800CA6867 /* DnDCharacterGenerator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DnDCharacterGenerator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		06A63562228755D800CA6867 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		06A63564228755D800CA6867 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -90,6 +92,7 @@
 			isa = PBXGroup;
 			children = (
 				06650D0B22885A0F00226AB6 /* CharacterClassQuery.graphql */,
+				06A03AAD228A0A4C0065A0E5 /* CharacterAttributesQuery.graphql */,
 			);
 			path = Queries;
 			sourceTree = "<group>";
@@ -253,6 +256,7 @@
 				06650D0E2288C38900226AB6 /* Images.xcassets in Resources */,
 				06A6356A228755DB00CA6867 /* Assets.xcassets in Resources */,
 				06A63568228755D800CA6867 /* Main.storyboard in Resources */,
+				06A03AAE228A0A4C0065A0E5 /* CharacterAttributesQuery.graphql in Resources */,
 				06650D102288E14600226AB6 /* Colors.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/DnDCharacterGenerator/API.swift
+++ b/DnDCharacterGenerator/API.swift
@@ -2,6 +2,219 @@
 
 import Apollo
 
+public final class CharacterAttributesQuery: GraphQLQuery {
+  public let operationDefinition =
+    "query CharacterAttributes {\n  classResult {\n    __typename\n    count\n    allClasses {\n      __typename\n      name\n    }\n  }\n  raceResult {\n    __typename\n    count\n    allRaces {\n      __typename\n      name\n    }\n  }\n}"
+
+  public init() {
+  }
+
+  public struct Data: GraphQLSelectionSet {
+    public static let possibleTypes = ["Query"]
+
+    public static let selections: [GraphQLSelection] = [
+      GraphQLField("classResult", type: .object(ClassResult.selections)),
+      GraphQLField("raceResult", type: .object(RaceResult.selections)),
+    ]
+
+    public private(set) var resultMap: ResultMap
+
+    public init(unsafeResultMap: ResultMap) {
+      self.resultMap = unsafeResultMap
+    }
+
+    public init(classResult: ClassResult? = nil, raceResult: RaceResult? = nil) {
+      self.init(unsafeResultMap: ["__typename": "Query", "classResult": classResult.flatMap { (value: ClassResult) -> ResultMap in value.resultMap }, "raceResult": raceResult.flatMap { (value: RaceResult) -> ResultMap in value.resultMap }])
+    }
+
+    public var classResult: ClassResult? {
+      get {
+        return (resultMap["classResult"] as? ResultMap).flatMap { ClassResult(unsafeResultMap: $0) }
+      }
+      set {
+        resultMap.updateValue(newValue?.resultMap, forKey: "classResult")
+      }
+    }
+
+    public var raceResult: RaceResult? {
+      get {
+        return (resultMap["raceResult"] as? ResultMap).flatMap { RaceResult(unsafeResultMap: $0) }
+      }
+      set {
+        resultMap.updateValue(newValue?.resultMap, forKey: "raceResult")
+      }
+    }
+
+    public struct ClassResult: GraphQLSelectionSet {
+      public static let possibleTypes = ["ClassResult"]
+
+      public static let selections: [GraphQLSelection] = [
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+        GraphQLField("count", type: .scalar(Int.self)),
+        GraphQLField("allClasses", type: .list(.object(AllClass.selections))),
+      ]
+
+      public private(set) var resultMap: ResultMap
+
+      public init(unsafeResultMap: ResultMap) {
+        self.resultMap = unsafeResultMap
+      }
+
+      public init(count: Int? = nil, allClasses: [AllClass?]? = nil) {
+        self.init(unsafeResultMap: ["__typename": "ClassResult", "count": count, "allClasses": allClasses.flatMap { (value: [AllClass?]) -> [ResultMap?] in value.map { (value: AllClass?) -> ResultMap? in value.flatMap { (value: AllClass) -> ResultMap in value.resultMap } } }])
+      }
+
+      public var __typename: String {
+        get {
+          return resultMap["__typename"]! as! String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "__typename")
+        }
+      }
+
+      public var count: Int? {
+        get {
+          return resultMap["count"] as? Int
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "count")
+        }
+      }
+
+      public var allClasses: [AllClass?]? {
+        get {
+          return (resultMap["allClasses"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [AllClass?] in value.map { (value: ResultMap?) -> AllClass? in value.flatMap { (value: ResultMap) -> AllClass in AllClass(unsafeResultMap: value) } } }
+        }
+        set {
+          resultMap.updateValue(newValue.flatMap { (value: [AllClass?]) -> [ResultMap?] in value.map { (value: AllClass?) -> ResultMap? in value.flatMap { (value: AllClass) -> ResultMap in value.resultMap } } }, forKey: "allClasses")
+        }
+      }
+
+      public struct AllClass: GraphQLSelectionSet {
+        public static let possibleTypes = ["Class"]
+
+        public static let selections: [GraphQLSelection] = [
+          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+          GraphQLField("name", type: .scalar(String.self)),
+        ]
+
+        public private(set) var resultMap: ResultMap
+
+        public init(unsafeResultMap: ResultMap) {
+          self.resultMap = unsafeResultMap
+        }
+
+        public init(name: String? = nil) {
+          self.init(unsafeResultMap: ["__typename": "Class", "name": name])
+        }
+
+        public var __typename: String {
+          get {
+            return resultMap["__typename"]! as! String
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "__typename")
+          }
+        }
+
+        public var name: String? {
+          get {
+            return resultMap["name"] as? String
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "name")
+          }
+        }
+      }
+    }
+
+    public struct RaceResult: GraphQLSelectionSet {
+      public static let possibleTypes = ["RaceResult"]
+
+      public static let selections: [GraphQLSelection] = [
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+        GraphQLField("count", type: .scalar(Int.self)),
+        GraphQLField("allRaces", type: .list(.object(AllRace.selections))),
+      ]
+
+      public private(set) var resultMap: ResultMap
+
+      public init(unsafeResultMap: ResultMap) {
+        self.resultMap = unsafeResultMap
+      }
+
+      public init(count: Int? = nil, allRaces: [AllRace?]? = nil) {
+        self.init(unsafeResultMap: ["__typename": "RaceResult", "count": count, "allRaces": allRaces.flatMap { (value: [AllRace?]) -> [ResultMap?] in value.map { (value: AllRace?) -> ResultMap? in value.flatMap { (value: AllRace) -> ResultMap in value.resultMap } } }])
+      }
+
+      public var __typename: String {
+        get {
+          return resultMap["__typename"]! as! String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "__typename")
+        }
+      }
+
+      public var count: Int? {
+        get {
+          return resultMap["count"] as? Int
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "count")
+        }
+      }
+
+      public var allRaces: [AllRace?]? {
+        get {
+          return (resultMap["allRaces"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [AllRace?] in value.map { (value: ResultMap?) -> AllRace? in value.flatMap { (value: ResultMap) -> AllRace in AllRace(unsafeResultMap: value) } } }
+        }
+        set {
+          resultMap.updateValue(newValue.flatMap { (value: [AllRace?]) -> [ResultMap?] in value.map { (value: AllRace?) -> ResultMap? in value.flatMap { (value: AllRace) -> ResultMap in value.resultMap } } }, forKey: "allRaces")
+        }
+      }
+
+      public struct AllRace: GraphQLSelectionSet {
+        public static let possibleTypes = ["Race"]
+
+        public static let selections: [GraphQLSelection] = [
+          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+          GraphQLField("name", type: .scalar(String.self)),
+        ]
+
+        public private(set) var resultMap: ResultMap
+
+        public init(unsafeResultMap: ResultMap) {
+          self.resultMap = unsafeResultMap
+        }
+
+        public init(name: String? = nil) {
+          self.init(unsafeResultMap: ["__typename": "Race", "name": name])
+        }
+
+        public var __typename: String {
+          get {
+            return resultMap["__typename"]! as! String
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "__typename")
+          }
+        }
+
+        public var name: String? {
+          get {
+            return resultMap["name"] as? String
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "name")
+          }
+        }
+      }
+    }
+  }
+}
+
 public final class CharacterClassQuery: GraphQLQuery {
   public let operationDefinition =
     "query CharacterClass {\n  classResult {\n    __typename\n    count\n    allClasses {\n      __typename\n      name\n    }\n  }\n}"

--- a/DnDCharacterGenerator/Base.lproj/Main.storyboard
+++ b/DnDCharacterGenerator/Base.lproj/Main.storyboard
@@ -20,7 +20,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="sunlit-path-ian-tormo" translatesAutoresizingMaskIntoConstraints="NO" id="He6-3j-ccJ">
-                                <rect key="frame" x="0.0" y="0.0" width="414.00000000000091" height="896"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="100" translatesAutoresizingMaskIntoConstraints="NO" id="TPN-ey-CrU">
                                 <rect key="frame" x="20" y="64" width="374" height="503"/>

--- a/DnDCharacterGenerator/Queries/CharacterAttributesQuery.graphql
+++ b/DnDCharacterGenerator/Queries/CharacterAttributesQuery.graphql
@@ -1,0 +1,15 @@
+query CharacterAttributes {
+    classResult {
+        count
+        allClasses {
+            name
+        }
+    }
+
+    raceResult {
+        count
+        allRaces {
+            name
+        }
+    }
+}

--- a/DnDCharacterGenerator/ViewController.swift
+++ b/DnDCharacterGenerator/ViewController.swift
@@ -57,7 +57,7 @@ class ViewController: UIViewController {
             clearLabels()
         } else {
             classLabel.text = allCharacterClasses.randomElement()
-            raceLabel.text = "Half-Orc"
+            raceLabel.text = allCharacterRaces.randomElement()
             alignmentLabel.text = "Chaotic Neutral"
         }
     }

--- a/DnDCharacterGenerator/ViewController.swift
+++ b/DnDCharacterGenerator/ViewController.swift
@@ -34,9 +34,28 @@ class ViewController: UIViewController {
     var isDataFetched: Bool = false
     var allCharacterClasses: [String] = []
     var allCharacterRaces: [String] = []
+    var allCharacterAlignments: [String] {
+        var alignments: [String] = []
+        let morals = ["Good", "Neutral", "Evil"]
+        let states = ["Lawful", "Neutral", "Chaotic"]
+        
+        for moral in morals {
+            for state in states {
+                if "\(state) \(moral)" == "Neutral Neutral" {
+                    let trueNeutral = "True Neutral"
+                    alignments.append(trueNeutral)
+                } else {
+                    alignments.append("\(state) \(moral)")
+                }
+            }
+        }
+        
+        return alignments
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        print("🧙🏾‍♀️ \(allCharacterAlignments)")
         clearLabels()
         tryDataFetch()
     }
@@ -58,7 +77,7 @@ class ViewController: UIViewController {
         } else {
             classLabel.text = allCharacterClasses.randomElement()
             raceLabel.text = allCharacterRaces.randomElement()
-            alignmentLabel.text = "Chaotic Neutral"
+            alignmentLabel.text = allCharacterAlignments.randomElement()
         }
     }
     

--- a/DnDCharacterGenerator/ViewController.swift
+++ b/DnDCharacterGenerator/ViewController.swift
@@ -30,9 +30,10 @@ class ViewController: UIViewController {
     @IBOutlet weak var backgroundImageView: UIImageView! 
     
     var gradientLayer: CAGradientLayer!
-    let characterClassQuery = CharacterClassQuery()
+    let characterAttributeQuery = CharacterAttributesQuery()
     var isDataFetched: Bool = false
     var allCharacterClasses: [String] = []
+    var allCharacterRaces: [String] = []
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -62,15 +63,21 @@ class ViewController: UIViewController {
     }
     
     private func tryDataFetch() {
-        ApolloService.shared.client.fetch(query: characterClassQuery) { results, error in
+        ApolloService.shared.client.fetch(query: characterAttributeQuery) { results, error in
             if error != nil {
                 self.isDataFetched = false
                 print("⛔️ Error in fetching response: \(String(describing: error))")
-            } else if let results = results?.data?.classResult?.allClasses?.compactMap({ $0 }) {
+            } else {
                 self.isDataFetched = true
-                print(results)
-                self.allCharacterClasses = results.map{ $0.name! }
+                guard let classResults = results?.data?.classResult?.allClasses?.compactMap({ $0 }),
+                      let raceResults = results?.data?.raceResult?.allRaces?.compactMap({ $0 })
+                else { return }
+                
+                print(classResults)
+                self.allCharacterClasses = classResults.map{ $0.name! }
+                self.allCharacterRaces = raceResults.map{ $0.name! }
                 print("⚔️ Classes: \(self.allCharacterClasses)")
+                print("🧝🏾‍♀️ Races: \(self.allCharacterRaces)")
             }
         }
     }

--- a/DnDCharacterGenerator/schema.json
+++ b/DnDCharacterGenerator/schema.json
@@ -24,29 +24,13 @@
             "deprecationReason": null
           },
           {
-            "name": "class",
+            "name": "raceResult",
             "description": "",
             "args": [],
             "type": {
               "kind": "OBJECT",
-              "name": "Class",
+              "name": "RaceResult",
               "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "allClasses",
-            "description": "",
-            "args": [],
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Class",
-                "ofType": null
-              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -136,6 +120,68 @@
         "fields": null,
         "inputFields": null,
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "RaceResult",
+        "description": "",
+        "fields": [
+          {
+            "name": "count",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "allRaces",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Race",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Race",
+        "description": "",
+        "fields": [
+          {
+            "name": "name",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },


### PR DESCRIPTION
## What does this PR do :question:
This PR contains changes that update the GraphQL schema and query used in the project (due to the update to the dnd-graphql server in [this PR](https://github.com/BritneyS/dnd-graphql/pull/4)). The character races now populate the `Race:` label. 

The alignments were added manually, since the [D&D API](http://www.dnd5eapi.co/docs/#resource-lists) doesn't provide them.

## How to test it :microscope:
⚙️**Precondition: The [dnd-graphql](https://github.com/BritneyS/dnd-graphql) server should be running on http://localhost:8000**
1. Checkout this branch
2. Run `pod install`
3. Run the app
4. Tap the 'Generate Character' button
5. Note that the app labels are now populated
6. Tapping the 'Generate Character' button repeatedly should populate different class, race, and alignment values in their respective labels




## Any background info you would like to include :white_check_mark:
N/A


## Screenshots (if applicable) :camera:
![dndgenerator-pr-update-schema](https://user-images.githubusercontent.com/8409475/57703386-f5be3500-762d-11e9-8549-295b71995e47.gif)
